### PR TITLE
fix: allow passing relative paths

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -7,7 +7,7 @@ var path = require('path')
 var args = [ path.join(__dirname, "..", "app") ];
 for (var i = 2; i < process.argv.length; i++) {
 	var arg = process.argv[i];
-	args.push(arg);
+	args.push(path.resolve(process.cwd(), arg));
 }
 
 


### PR DESCRIPTION
if i'm on the project directory and try to run `iron-node` without an absolute path it will not find the module.

This fix make it safe to pass relative paths.

Without the fix this doesn't work:

``` sh
~/git/my-project - $ iron-node myfile.js
```

With the fix works in a safe way, it will resolve the paths even if you already specify an absolute path
